### PR TITLE
Add proxy option for non-tastypie endpoints

### DIFF
--- a/testem.json
+++ b/testem.json
@@ -14,6 +14,9 @@
   "proxies": {
     "/api": {
       "target": "http://localhost:9001"
+    },
+    "/custom_api": {
+      "target": "http://localhost:9001"
     }
   }
 }


### PR DESCRIPTION
Background: before, if you run glue tests on pages that fetch data from non-tastypie endpoints, you will get 404 error. This is because we've only set up proxy for tastypie API but none for custom views in our testem configuration. 
This PR adds an additional proxy option in testem configuration file 
```
"proxies": {
    "/api": {
      "target": "http://localhost:9001"
    },
    "/custom_api": {
      "target": "http://localhost:9001"
    }
  }
```
this new added proxy will be used for all custom views with a set prefix '/custom_api', which means, to have glue tests work for your non-tastypie endpoints, you will need to change your endpoint to have this prefix (also remember to update wherever it is being used in the app). 
