### PR TITLE
GraphQL support for glue tests

### DIFF
--- a/bin/runner.js
+++ b/bin/runner.js
@@ -5,6 +5,7 @@ var path = require('path');
 var args = process.argv.slice(3);
 var projectPath = process.argv[2];
 var Bridge = require('../lib/proxy_bridge').Bridge;
+var startGraphqlServer = require('../lib/graphql').startGraphqlServer;
 var bridge;
 var testemPath = require.resolve('testem').replace('/lib/api.js', '');
 var program = require('commander')
@@ -81,6 +82,10 @@ function main(){
 
     bridge = new Bridge(program.channel_uuid);
     bridge.start();
+
+    process.env.PORT = '9002'
+    process.env.BASEURL = 'http://localhost:9001'
+    startGraphqlServer();
 
     api.setup = function(mode, finalizer) {
       var self = this;

--- a/lib/graphql.js
+++ b/lib/graphql.js
@@ -1,0 +1,16 @@
+require('babel-register');
+
+var zgraphql = require('zgraphql');
+var path = require('path');
+
+function schemaProvider(callback) {
+  var schemaDir = path.resolve(process.cwd(), '../graphql/schema/schema');
+  var localSchema = require(schemaDir);
+  callback(localSchema.schemas, localSchema.resolvers, localSchema.queries);
+};
+
+function startGraphqlServer() {
+  zgraphql.start(schemaProvider, { devMode: true });
+}
+
+exports.startGraphqlServer = startGraphqlServer;

--- a/lib/graphql.js
+++ b/lib/graphql.js
@@ -1,7 +1,9 @@
-require('babel-register');
-
-var zgraphql = require('zgraphql');
 var path = require('path');
+
+// this is awkward but if we don't do it this way the schema load gets it's own copy of zgraphql and bad things happen
+var graphqlNodeModulesDir = path.resolve(process.cwd(), 'graphql/node_modules');
+var zgraphql = require(path.resolve(graphqlNodeModulesDir, 'zgraphql'));
+require(path.resolve(graphqlNodeModulesDir, 'babel-register'));
 
 function schemaProvider(callback) {
   var schemaDir = path.resolve(process.cwd(), '../graphql/schema/schema');

--- a/package.json
+++ b/package.json
@@ -9,13 +9,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "babel-register": "^6.26.0",
     "commander": "^2.8.1",
     "dependency-checker": "git+https://github.com/zenefits/dependency-checker#v0.0.2",
     "npmlog": "^1.2.1",
     "redis": "^0.12.1",
-    "testem": "git+https://github.com/zenefits/testem#v1.6.0-zenefits.2",
-    "zgraphql": "git+ssh://git@github.com/zenefits/zgraphql#v0.5.3"
+    "testem": "git+https://github.com/zenefits/testem#v1.6.0-zenefits.2"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testem-wrap",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "babel-register": "^6.26.0",
     "commander": "^2.8.1",
     "dependency-checker": "git+https://github.com/zenefits/dependency-checker#v0.0.2",
     "npmlog": "^1.2.1",
     "redis": "^0.12.1",
-    "testem": "git+https://github.com/zenefits/testem#v1.6.0-zenefits.2"
+    "testem": "git+https://github.com/zenefits/testem#v1.6.0-zenefits.2",
+    "zgraphql": "git+ssh://git@github.com/zenefits/zgraphql#v0.5.3"
   },
   "repository": {
     "type": "git",

--- a/testem.json
+++ b/testem.json
@@ -15,6 +15,9 @@
     "/api": {
       "target": "http://localhost:9001"
     },
+    "/graphql": {
+      "target": "http://localhost:9002"
+    },
     "/custom_api": {
       "target": "http://localhost:9001"
     },


### PR DESCRIPTION
It's becoming more common for Ember to call GraphQL but currently this doesn't work in glue tests.

Adds another proxy rule to testem and boots a graphql server in the testem-wrap (similar to how the bridge is booted).