### PR TITLE
Fix error when body exceeds buffer

### DIFF
--- a/lib/proxy_bridge.js
+++ b/lib/proxy_bridge.js
@@ -94,7 +94,7 @@ Bridge.prototype = new (function () {
     dmn.add(resp);
 
     dmn.run(function () {
-      self.currReqId++;
+      const id = self.currReqId++;
 
       // Buffer the body if needed
       if (_expectBody(req)) {
@@ -109,17 +109,16 @@ Bridge.prototype = new (function () {
 
         req.addListener('end', function () {
           req.body = body;
-          handle(req, resp);
+          handle(req, resp, id);
         });
       }
       else {
-        handle(req, resp);
+        handle(req, resp, id);
       }
     });
   };
 
-  this.handleRequest = function  (req, resp) {
-    var id = this.currReqId;
+  this.handleRequest = function  (req, resp, id) {
     var req = {
       reqId: id,
       method: req.method,


### PR DESCRIPTION
- Previously we weren't getting the id until req.end event fired. If the body doesn't fit in the buffer this won't happen right away.
  - As a result we were using the same id for multiple messages

The reason this started happening now was that in https://github.com/zenefits/z-frontend/commit/5f5c0c4852b615fb44ceb3aa47797f4daacbb0b9 we started adding entire logs to the a batch log element rather than just properties. We needed this since different logs in a batch could have different context, appName etc. (There might be a better way of doing this for larger payloads but can revisit)